### PR TITLE
fix: preserve Facebook link destinations in Glow

### DIFF
--- a/.github/workflows/link-router.yml
+++ b/.github/workflows/link-router.yml
@@ -7,7 +7,6 @@ on:
       - "LinkRouter/**"
       - "scripts/embed-glow-link-router.sh"
   push:
-    branches: [main]
     paths:
       - ".github/workflows/link-router.yml"
       - "LinkRouter/**"

--- a/.github/workflows/link-router.yml
+++ b/.github/workflows/link-router.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install project generator
         run: brew install xcodegen

--- a/.github/workflows/link-router.yml
+++ b/.github/workflows/link-router.yml
@@ -1,0 +1,46 @@
+name: Link Router
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/link-router.yml"
+      - "LinkRouter/**"
+      - "scripts/embed-glow-link-router.sh"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/link-router.yml"
+      - "LinkRouter/**"
+      - "scripts/embed-glow-link-router.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-build:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install project generator
+        run: brew install xcodegen
+
+      - name: Test routes
+        run: LinkRouter/test.sh
+
+      - name: Generate extension project
+        run: xcodegen generate --spec LinkRouter/project.yml --project LinkRouter
+
+      - name: Build extensions without signing
+        run: |
+          for scheme in GlowLinkShare GlowSafariRedirect; do
+            xcodebuild \
+              -project LinkRouter/GlowLinkRouter.xcodeproj \
+              -scheme "$scheme" \
+              -configuration Release \
+              -sdk iphoneos \
+              -derivedDataPath LinkRouter/.build \
+              CODE_SIGNING_ALLOWED=NO \
+              build
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,10 @@ jobs:
           fi
 
       - name: Install Dependencies
-        run: brew install make ldid
+        run: brew install make ldid xcodegen
 
       - name: Set PATH environment variable
-        run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
+        run: echo "$(brew --prefix make)/libexec/gnubin" >> "$GITHUB_PATH"
 
       - name: Install cyan
         run: pipx install --force https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
@@ -84,12 +84,15 @@ jobs:
             exit 1
           fi
 
-          echo "GLOW_TAG=$tag_name" >> $GITHUB_ENV
+          echo "GLOW_TAG=$tag_name" >> "$GITHUB_ENV"
           echo "Downloading: $deb_url"
-          wget "$deb_url" --no-verbose -O ${{ github.workspace }}/glow_fb.deb
+          wget "$deb_url" --no-verbose -O "${{ github.workspace }}/glow_fb.deb"
 
       - name: Inject tweaks into IPA
-        run: cyan -i facebook.ipa -o Glow_FB_${{ env.GLOW_TAG }}.ipa -uwef glow_fb.deb -n "${{ inputs.display_name }}" -b ${{ inputs.bundle_id }} -s
+        env:
+          BUNDLE_ID: ${{ inputs.bundle_id }}
+          DISPLAY_NAME: ${{ inputs.display_name }}
+        run: cyan -i facebook.ipa -o "Glow_FB_${GLOW_TAG}.ipa" -uwef glow_fb.deb -n "$DISPLAY_NAME" -b "$BUNDLE_ID" -s
 
       - name: Strip embedded Swift dylibs
         run: |
@@ -99,6 +102,13 @@ jobs:
           zip -qr ../Glow_FB_${{ env.GLOW_TAG }}_clean.ipa Payload
           cd ..
           mv Glow_FB_${{ env.GLOW_TAG }}_clean.ipa Glow_FB_${{ env.GLOW_TAG }}.ipa
+
+      - name: Embed destination-preserving link router
+        run: |
+          main/scripts/embed-glow-link-router.sh \
+            Glow_FB_${{ env.GLOW_TAG }}.ipa \
+            Glow_FB_${{ env.GLOW_TAG }}_with_router.ipa
+          mv Glow_FB_${{ env.GLOW_TAG }}_with_router.ipa Glow_FB_${{ env.GLOW_TAG }}.ipa
 
       - uses: softprops/action-gh-release@v2.0.1
         with:

--- a/LinkRouter/.gitignore
+++ b/LinkRouter/.gitignore
@@ -1,0 +1,4 @@
+.build/
+GlowLinkRouter.xcodeproj/
+Info.plist
+SafariExtension-Info.plist

--- a/LinkRouter/SafariExtensionResources/manifest.json
+++ b/LinkRouter/SafariExtensionResources/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Open Facebook in Glow",
   "description": "Hands Facebook web links to the installed Facebook Glow app.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "content_scripts": [
     {
       "matches": [

--- a/LinkRouter/SafariExtensionResources/manifest.json
+++ b/LinkRouter/SafariExtensionResources/manifest.json
@@ -1,0 +1,44 @@
+{
+  "manifest_version": 3,
+  "name": "Open Facebook in Glow",
+  "description": "Hands Facebook web links to the installed Facebook Glow app.",
+  "version": "1.0.0",
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*.facebook.com/*",
+        "https://*.facebook.com/*",
+        "http://facebook.com/*",
+        "https://facebook.com/*",
+        "http://*.fb.com/*",
+        "https://*.fb.com/*",
+        "http://fb.com/*",
+        "https://fb.com/*",
+        "http://fb.me/*",
+        "https://fb.me/*",
+        "http://fb.watch/*",
+        "https://fb.watch/*",
+        "http://fbwat.ch/*",
+        "https://fbwat.ch/*"
+      ],
+      "js": ["redirect.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "host_permissions": [
+    "http://*.facebook.com/*",
+    "https://*.facebook.com/*",
+    "http://facebook.com/*",
+    "https://facebook.com/*",
+    "http://*.fb.com/*",
+    "https://*.fb.com/*",
+    "http://fb.com/*",
+    "https://fb.com/*",
+    "http://fb.me/*",
+    "https://fb.me/*",
+    "http://fb.watch/*",
+    "https://fb.watch/*",
+    "http://fbwat.ch/*",
+    "https://fbwat.ch/*"
+  ]
+}

--- a/LinkRouter/SafariExtensionResources/manifest.json
+++ b/LinkRouter/SafariExtensionResources/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Open Facebook in Glow",
   "description": "Hands Facebook web links to the installed Facebook Glow app.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "content_scripts": [
     {
       "matches": [
@@ -22,7 +22,7 @@
         "https://fbwat.ch/*"
       ],
       "js": ["redirect.js"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ],
   "host_permissions": [

--- a/LinkRouter/SafariExtensionResources/manifest.json
+++ b/LinkRouter/SafariExtensionResources/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Open Facebook in Glow",
   "description": "Hands Facebook web links to the installed Facebook Glow app.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "content_scripts": [
     {
       "matches": [

--- a/LinkRouter/SafariExtensionResources/redirect.js
+++ b/LinkRouter/SafariExtensionResources/redirect.js
@@ -1,0 +1,90 @@
+(() => {
+  "use strict";
+
+  const allowedDomains = ["facebook.com", "fb.com", "fb.me", "fb.watch", "fbwat.ch"];
+  const allowedNativeSchemes = new Set([
+    "fb:",
+    "facebook-reels:",
+    "facebook-stories:",
+    "facebook-stories-list:"
+  ]);
+  const host = window.location.hostname.toLowerCase().replace(/\.$/, "");
+  const allowed = allowedDomains.some((domain) => host === domain || host.endsWith(`.${domain}`));
+  if (!allowed || !["http:", "https:"].includes(window.location.protocol)) {
+    return;
+  }
+
+  const marker = `glow-redirect:${window.location.href}`;
+
+  function nativeRouteFromPage() {
+    const elements = document.querySelectorAll('meta[property="al:ios:url"]');
+    for (const element of elements) {
+      const content = element.getAttribute("content")?.trim();
+      if (!content) {
+        continue;
+      }
+      try {
+        const candidate = new URL(content);
+        if (allowedNativeSchemes.has(candidate.protocol)) {
+          return candidate.href;
+        }
+      } catch (_error) {
+        // Ignore malformed metadata and use the validated web URL fallback.
+      }
+    }
+    return undefined;
+  }
+
+  function validatedWebURL(rawValue) {
+    if (!rawValue) {
+      return undefined;
+    }
+    try {
+      const candidate = new URL(rawValue, window.location.href);
+      const candidateHost = candidate.hostname.toLowerCase().replace(/\.$/, "");
+      const candidateAllowed = allowedDomains.some(
+        (domain) => candidateHost === domain || candidateHost.endsWith(`.${domain}`)
+      );
+      if (
+        candidateAllowed &&
+        ["http:", "https:"].includes(candidate.protocol) &&
+        !candidate.username &&
+        !candidate.password &&
+        !candidate.port
+      ) {
+        return candidate;
+      }
+    } catch (_error) {
+      // Ignore malformed canonical metadata.
+    }
+    return undefined;
+  }
+
+  function canonicalWebURL() {
+    const canonical = document.querySelectorAll('link[rel="canonical"]')[0]?.getAttribute("href");
+    const openGraph = document.querySelectorAll('meta[property="og:url"]')[0]?.getAttribute("content");
+    return validatedWebURL(window.location.href) || validatedWebURL(canonical) || validatedWebURL(openGraph);
+  }
+
+  function wwwLinkRoute() {
+    const webURL = canonicalWebURL();
+    return webURL
+      ? `fb-www-link://www_link/?url=${encodeURIComponent(webURL.href)}`
+      : undefined;
+  }
+
+  function redirectIfReady() {
+    if (window.sessionStorage.getItem(marker) === "attempted") {
+      return true;
+    }
+    const target = nativeRouteFromPage() || wwwLinkRoute();
+    if (!target) {
+      return false;
+    }
+    window.sessionStorage.setItem(marker, "attempted");
+    window.location.replace(target);
+    return true;
+  }
+
+  redirectIfReady();
+})();

--- a/LinkRouter/SafariExtensionResources/redirect.js
+++ b/LinkRouter/SafariExtensionResources/redirect.js
@@ -123,14 +123,15 @@
   }
 
   function redirectIfReady() {
-    if (window.sessionStorage.getItem(marker) === "attempted") {
+    const lastAttempt = Number(window.sessionStorage.getItem(marker));
+    if (Number.isFinite(lastAttempt) && Date.now() - lastAttempt < 10000) {
       return true;
     }
     const currentURL = validatedWebURL(window.location.href);
     if (!currentURL) {
       return false;
     }
-    window.sessionStorage.setItem(marker, "attempted");
+    window.sessionStorage.setItem(marker, String(Date.now()));
     if (/^\/share\/(?:p|r|v)(?:\/|$)/i.test(currentURL.pathname)) {
       void resolveShareWrapper(currentURL);
       return true;

--- a/LinkRouter/SafariExtensionResources/redirect.js
+++ b/LinkRouter/SafariExtensionResources/redirect.js
@@ -63,7 +63,25 @@
   function canonicalWebURL() {
     const canonical = document.querySelectorAll('link[rel="canonical"]')[0]?.getAttribute("href");
     const openGraph = document.querySelectorAll('meta[property="og:url"]')[0]?.getAttribute("content");
-    return validatedWebURL(window.location.href) || validatedWebURL(canonical) || validatedWebURL(openGraph);
+    const currentURL = validatedWebURL(window.location.href);
+    const canonicalURL = validatedWebURL(canonical);
+    const openGraphURL = validatedWebURL(openGraph);
+    if (!currentURL) {
+      return canonicalURL || openGraphURL;
+    }
+
+    const isShareWrapper = /^\/share\/(?:p|r|v)(?:\/|$)/i.test(currentURL.pathname);
+    if (!isShareWrapper) {
+      return currentURL;
+    }
+
+    const resolvedDestination = [canonicalURL, openGraphURL].find(
+      (candidate) =>
+        candidate &&
+        candidate.pathname !== "/" &&
+        !/^\/share\/(?:p|r|v)(?:\/|$)/i.test(candidate.pathname)
+    );
+    return resolvedDestination || currentURL;
   }
 
   function wwwLinkRoute() {

--- a/LinkRouter/SafariExtensionResources/redirect.js
+++ b/LinkRouter/SafariExtensionResources/redirect.js
@@ -60,12 +60,19 @@
     return undefined;
   }
 
-  function canonicalWebURL() {
-    const canonical = document.querySelectorAll('link[rel="canonical"]')[0]?.getAttribute("href");
-    const openGraph = document.querySelectorAll('meta[property="og:url"]')[0]?.getAttribute("content");
-    const currentURL = validatedWebURL(window.location.href);
-    const canonicalURL = validatedWebURL(canonical);
-    const openGraphURL = validatedWebURL(openGraph);
+  function canonicalWebURL(sourceDocument = document) {
+    const canonical = sourceDocument.querySelectorAll('link[rel="canonical"]')[0]?.getAttribute("href");
+    const openGraph = sourceDocument
+      .querySelectorAll('meta[property="og:url"]')[0]
+      ?.getAttribute("content");
+    return canonicalDestination(
+      validatedWebURL(window.location.href),
+      validatedWebURL(canonical),
+      validatedWebURL(openGraph)
+    );
+  }
+
+  function canonicalDestination(currentURL, canonicalURL, openGraphURL) {
     if (!currentURL) {
       return canonicalURL || openGraphURL;
     }
@@ -84,23 +91,51 @@
     return resolvedDestination || currentURL;
   }
 
-  function wwwLinkRoute() {
-    const webURL = canonicalWebURL();
+  function wwwLinkRoute(webURL = canonicalWebURL()) {
     return webURL
       ? `fb-www-link://www_link/?url=${encodeURIComponent(webURL.href)}`
       : undefined;
+  }
+
+  function redirect(target) {
+    if (!target) {
+      return false;
+    }
+    window.location.replace(target);
+    return true;
+  }
+
+  async function resolveShareWrapper(currentURL) {
+    window.stop();
+    try {
+      const response = await window.fetch(currentURL.href, {
+        cache: "no-store",
+        credentials: "include"
+      });
+      if (!response.ok) {
+        throw new Error(`Facebook returned HTTP ${response.status}`);
+      }
+      const parsedDocument = new DOMParser().parseFromString(await response.text(), "text/html");
+      redirect(wwwLinkRoute(canonicalWebURL(parsedDocument)));
+    } catch (_error) {
+      redirect(wwwLinkRoute(currentURL));
+    }
   }
 
   function redirectIfReady() {
     if (window.sessionStorage.getItem(marker) === "attempted") {
       return true;
     }
-    const target = nativeRouteFromPage() || wwwLinkRoute();
-    if (!target) {
+    const currentURL = validatedWebURL(window.location.href);
+    if (!currentURL) {
       return false;
     }
     window.sessionStorage.setItem(marker, "attempted");
-    window.location.replace(target);
+    if (/^\/share\/(?:p|r|v)(?:\/|$)/i.test(currentURL.pathname)) {
+      void resolveShareWrapper(currentURL);
+      return true;
+    }
+    redirect(nativeRouteFromPage() || wwwLinkRoute(currentURL));
     return true;
   }
 

--- a/LinkRouter/SafariExtensionSources/GlowSafariWebExtensionHandler.m
+++ b/LinkRouter/SafariExtensionSources/GlowSafariWebExtensionHandler.m
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+@interface GlowSafariWebExtensionHandler : NSObject <NSExtensionRequestHandling>
+@end
+
+@implementation GlowSafariWebExtensionHandler
+
+- (void)beginRequestWithExtensionContext:(NSExtensionContext *)context {
+    [context completeRequestReturningItems:context.inputItems completionHandler:nil];
+}
+
+@end

--- a/LinkRouter/Sources/GlowLinkRouting.h
+++ b/LinkRouter/Sources/GlowLinkRouting.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT BOOL GlowLinkHostIsAllowed(NSString *host);
+FOUNDATION_EXPORT NSURL * _Nullable GlowLinkURLForFacebookURL(NSURL *inputURL);
+FOUNDATION_EXPORT NSURL * _Nullable GlowLinkURLFromText(NSString *text);
+
+NS_ASSUME_NONNULL_END

--- a/LinkRouter/Sources/GlowLinkRouting.m
+++ b/LinkRouter/Sources/GlowLinkRouting.m
@@ -1,0 +1,70 @@
+#import "GlowLinkRouting.h"
+
+static NSArray<NSString *> *GlowLinkAllowedDomains(void) {
+    static NSArray<NSString *> *domains;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        domains = @[
+            @"facebook.com",
+            @"fb.com",
+            @"fb.me",
+            @"fb.watch",
+            @"fbwat.ch"
+        ];
+    });
+    return domains;
+}
+
+BOOL GlowLinkHostIsAllowed(NSString *host) {
+    NSString *normalized = host.lowercaseString;
+    if (normalized.length == 0) {
+        return NO;
+    }
+
+    for (NSString *domain in GlowLinkAllowedDomains()) {
+        if ([normalized isEqualToString:domain] ||
+            [normalized hasSuffix:[@"." stringByAppendingString:domain]]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+NSURL *GlowLinkURLForFacebookURL(NSURL *inputURL) {
+    if (inputURL == nil || inputURL.user.length > 0 || inputURL.password.length > 0 ||
+        inputURL.port != nil || !GlowLinkHostIsAllowed(inputURL.host ?: @"")) {
+        return nil;
+    }
+
+    NSString *scheme = inputURL.scheme.lowercaseString;
+    if (![scheme isEqualToString:@"https"] && ![scheme isEqualToString:@"http"]) {
+        return nil;
+    }
+    return inputURL;
+}
+
+NSURL *GlowLinkURLFromText(NSString *text) {
+    if (text.length == 0) {
+        return nil;
+    }
+
+    NSError *error = nil;
+    NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:&error];
+    if (detector == nil || error != nil) {
+        return nil;
+    }
+
+    __block NSURL *result = nil;
+    [detector enumerateMatchesInString:text
+                               options:0
+                                 range:NSMakeRange(0, text.length)
+                            usingBlock:^(NSTextCheckingResult *match, NSMatchingFlags flags, BOOL *stop) {
+        (void)flags;
+        NSURL *candidate = GlowLinkURLForFacebookURL(match.URL);
+        if (candidate != nil) {
+            result = candidate;
+            *stop = YES;
+        }
+    }];
+    return result;
+}

--- a/LinkRouter/Sources/GlowLinkShareViewController.m
+++ b/LinkRouter/Sources/GlowLinkShareViewController.m
@@ -1,0 +1,179 @@
+#import <UIKit/UIKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <objc/message.h>
+
+#import "GlowLinkRouting.h"
+
+static NSString *GlowLinkAttributedText(NSArray *items) {
+    for (NSExtensionItem *item in items) {
+        if (item.attributedContentText.string.length > 0) {
+            return item.attributedContentText.string;
+        }
+    }
+    return @"";
+}
+
+@interface GlowLinkShareViewController : UIViewController
+@property(nonatomic, strong) UILabel *statusLabel;
+@property(nonatomic, strong) UIButton *openButton;
+@property(nonatomic, strong, nullable) NSURL *pendingURL;
+@property(nonatomic, assign) BOOL started;
+@end
+
+@implementation GlowLinkShareViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+
+    UILabel *titleLabel = [[UILabel alloc] init];
+    titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    titleLabel.text = @"Open in Facebook Glow";
+
+    self.statusLabel = [[UILabel alloc] init];
+    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.statusLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    self.statusLabel.numberOfLines = 0;
+    self.statusLabel.text = @"Reading the shared Facebook link...";
+
+    self.openButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.openButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.openButton setTitle:@"Open Facebook Glow" forState:UIControlStateNormal];
+    self.openButton.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    self.openButton.hidden = YES;
+    [self.openButton addTarget:self action:@selector(openPendingURL) forControlEvents:UIControlEventTouchUpInside];
+
+    UIButton *cancelButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    cancelButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [cancelButton setTitle:@"Cancel" forState:UIControlStateNormal];
+    [cancelButton addTarget:self action:@selector(cancel) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[titleLabel, self.statusLabel, self.openButton, cancelButton]];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 18.0;
+    stack.alignment = UIStackViewAlignmentFill;
+    [self.view addSubview:stack];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.leadingAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.leadingAnchor],
+        [stack.trailingAnchor constraintEqualToAnchor:self.view.layoutMarginsGuide.trailingAnchor],
+        [stack.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    ]];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    if (!self.started) {
+        self.started = YES;
+        [self resolveSharedURL];
+    }
+}
+
+- (void)resolveSharedURL {
+    for (NSExtensionItem *item in self.extensionContext.inputItems) {
+        for (NSItemProvider *provider in item.attachments) {
+            if ([provider hasItemConformingToTypeIdentifier:UTTypeURL.identifier]) {
+                [provider loadItemForTypeIdentifier:UTTypeURL.identifier options:nil completionHandler:^(id<NSSecureCoding> value, NSError *error) {
+                    (void)error;
+                    id object = (id)value;
+                    NSURL *url = [object isKindOfClass:NSURL.class] ? (NSURL *)object : nil;
+                    [self handleRoutedURL:GlowLinkURLForFacebookURL(url)];
+                }];
+                return;
+            }
+            if ([provider hasItemConformingToTypeIdentifier:UTTypePlainText.identifier]) {
+                [provider loadItemForTypeIdentifier:UTTypePlainText.identifier options:nil completionHandler:^(id<NSSecureCoding> value, NSError *error) {
+                    (void)error;
+                    id object = (id)value;
+                    NSString *text = [object isKindOfClass:NSString.class] ? (NSString *)object : nil;
+                    [self handleRoutedURL:GlowLinkURLFromText(text ?: @"")];
+                }];
+                return;
+            }
+        }
+    }
+
+    [self handleRoutedURL:GlowLinkURLFromText(GlowLinkAttributedText(self.extensionContext.inputItems))];
+}
+
+- (void)handleRoutedURL:(NSURL *)routedURL {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (routedURL == nil) {
+            self.statusLabel.text = @"This item does not contain a supported Facebook link.";
+            self.openButton.hidden = YES;
+            return;
+        }
+        self.pendingURL = routedURL;
+        self.statusLabel.text = @"Ready to open this link through Safari's Facebook Glow router.";
+        self.openButton.hidden = NO;
+        [self openPendingURL];
+    });
+}
+
+- (void)openPendingURL {
+    NSURL *url = self.pendingURL;
+    if (url == nil) {
+        return;
+    }
+    self.statusLabel.text = @"Opening the Facebook link...";
+    self.openButton.enabled = NO;
+
+    [self.extensionContext openURL:url completionHandler:^(BOOL success) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                [self complete];
+            } else {
+                [self openThroughHostApplication:url];
+            }
+        });
+    }];
+}
+
+- (void)openThroughHostApplication:(NSURL *)url {
+    Class applicationClass = NSClassFromString(@"UIApplication");
+    SEL sharedSelector = NSSelectorFromString(@"sharedApplication");
+    SEL openSelector = NSSelectorFromString(@"openURL:options:completionHandler:");
+    if (applicationClass == Nil || ![applicationClass respondsToSelector:sharedSelector]) {
+        [self showOpenFailure];
+        return;
+    }
+
+    id (*sendShared)(id, SEL) = (void *)objc_msgSend;
+    id application = sendShared(applicationClass, sharedSelector);
+    if (![application respondsToSelector:openSelector]) {
+        [self showOpenFailure];
+        return;
+    }
+
+    void (*sendOpen)(id, SEL, NSURL *, NSDictionary *, void (^)(BOOL)) = (void *)objc_msgSend;
+    sendOpen(application, openSelector, url, @{}, ^(BOOL success) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                [self complete];
+            } else {
+                [self showOpenFailure];
+            }
+        });
+    });
+}
+
+- (void)showOpenFailure {
+    self.statusLabel.text = @"iOS blocked the app handoff. Tap Open Facebook Glow to retry.";
+    self.openButton.enabled = YES;
+    self.openButton.hidden = NO;
+}
+
+- (void)complete {
+    [self.extensionContext completeRequestReturningItems:@[] completionHandler:nil];
+}
+
+- (void)cancel {
+    NSError *error = [NSError errorWithDomain:@"com.facebook.GlowLinkShare"
+                                         code:1
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Cancelled by user"}];
+    [self.extensionContext cancelRequestWithError:error];
+}
+
+@end

--- a/LinkRouter/Tests/GlowLinkRoutingTests.m
+++ b/LinkRouter/Tests/GlowLinkRoutingTests.m
@@ -1,0 +1,40 @@
+#import <Foundation/Foundation.h>
+
+#import "../Sources/GlowLinkRouting.h"
+
+static void AssertEqual(NSString *name, NSString *actual, NSString *expected) {
+    if ((actual == nil && expected != nil) || ![actual isEqualToString:expected]) {
+        NSLog(@"FAIL %@ expected=%@ actual=%@", name, expected, actual);
+        exit(1);
+    }
+}
+
+static void AssertNil(NSString *name, id value) {
+    if (value != nil) {
+        NSLog(@"FAIL %@ expected nil actual=%@", name, value);
+        exit(1);
+    }
+}
+
+int main(void) {
+    @autoreleasepool {
+        AssertEqual(@"reel",
+                    GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://www.facebook.com/reel/123?mibextid=abc"]).absoluteString,
+                    @"https://www.facebook.com/reel/123?mibextid=abc");
+        AssertEqual(@"watch short link",
+                    GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://fb.watch/example/"]).absoluteString,
+                    @"https://fb.watch/example/");
+        AssertEqual(@"text extraction",
+                    GlowLinkURLFromText(@"See https://facebook.com/groups/123/posts/456").absoluteString,
+                    @"https://facebook.com/groups/123/posts/456");
+
+        AssertNil(@"lookalike host", GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://evilfacebook.com/reel/1"]));
+        AssertNil(@"suffix attack", GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://facebook.com.evil.example/reel/1"]));
+        AssertNil(@"userinfo", GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://user@facebook.com/reel/1"]));
+        AssertNil(@"port", GlowLinkURLForFacebookURL([NSURL URLWithString:@"https://facebook.com:444/reel/1"]));
+        AssertNil(@"custom scheme", GlowLinkURLForFacebookURL([NSURL URLWithString:@"javascript://facebook.com/alert(1)"]));
+        AssertNil(@"no Facebook URL", GlowLinkURLFromText(@"https://example.com/not-facebook"));
+        NSLog(@"PASS GlowLinkRoutingTests");
+    }
+    return 0;
+}

--- a/LinkRouter/Tests/GlowSafariRedirectTests.js
+++ b/LinkRouter/Tests/GlowSafariRedirectTests.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const script = fs.readFileSync(
+  path.join(__dirname, "..", "SafariExtensionResources", "redirect.js"),
+  "utf8"
+);
+
+function redirectFor(href, options = {}) {
+  const url = new URL(href);
+  let redirected;
+  const storage = new Map();
+  const window = {
+    location: {
+      href,
+      hostname: url.hostname,
+      protocol: url.protocol,
+      replace(target) {
+        redirected = target;
+      }
+    },
+    sessionStorage: {
+      getItem(key) {
+        return storage.get(key) ?? null;
+      },
+      setItem(key, value) {
+        storage.set(key, value);
+      }
+    }
+  };
+  const document = {
+    querySelectorAll(selector) {
+      let values = [];
+      if (selector === 'meta[property="al:ios:url"]') {
+        values = options.nativeRoutes ?? [];
+      } else if (selector === 'link[rel="canonical"]' && options.canonical) {
+        values = [options.canonical];
+      } else if (selector === 'meta[property="og:url"]' && options.openGraph) {
+        values = [options.openGraph];
+      }
+      return values.map((content) => ({
+        getAttribute(name) {
+          return name === "content" || name === "href" ? content : null;
+        }
+      }));
+    }
+  };
+
+  vm.runInNewContext(script, {URL, document, window});
+  return redirected;
+}
+
+assert.equal(
+  redirectFor("https://www.facebook.com/reel/123?ref=share#clip", {
+    nativeRoutes: ["fb://reel/123?ref=share"]
+  }),
+  "fb://reel/123?ref=share"
+);
+assert.equal(
+  redirectFor("https://www.facebook.com/share/r/abc/?mibextid=xyz", {
+    nativeRoutes: ["https://evil.example/payload"]
+  }),
+  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Fshare%2Fr%2Fabc%2F%3Fmibextid%3Dxyz"
+);
+assert.equal(redirectFor("https://facebook.com.example/reel/123"), undefined);
+assert.equal(redirectFor("https://notfacebook.com/reel/123"), undefined);
+assert.equal(
+  redirectFor(
+    "https://www.facebook.com/reel/1071097325498008/?referral_source=external_link&surface_type=tab&in_reels_tab_context=TRUE"
+  ),
+  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Freel%2F1071097325498008%2F%3Freferral_source%3Dexternal_link%26surface_type%3Dtab%26in_reels_tab_context%3DTRUE"
+);
+
+console.log("PASS GlowSafariRedirectTests");

--- a/LinkRouter/Tests/GlowSafariRedirectTests.js
+++ b/LinkRouter/Tests/GlowSafariRedirectTests.js
@@ -62,9 +62,24 @@ assert.equal(
 );
 assert.equal(
   redirectFor("https://www.facebook.com/share/r/abc/?mibextid=xyz", {
-    nativeRoutes: ["https://evil.example/payload"]
+    nativeRoutes: ["https://evil.example/payload"],
+    canonical: "https://www.facebook.com/reel/123"
   }),
-  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Fshare%2Fr%2Fabc%2F%3Fmibextid%3Dxyz"
+  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Freel%2F123"
+);
+assert.equal(
+  redirectFor("https://www.facebook.com/share/v/19RsNqHveR/?mibextid=wwXIfr", {
+    canonical: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/",
+    openGraph: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/"
+  }),
+  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2FMEMES.of.the.NFL%2Fposts%2F1467604858743867%2F"
+);
+assert.equal(
+  redirectFor("https://www.facebook.com/share/v/abc", {
+    canonical: "https://www.facebook.com/",
+    openGraph: "https://www.facebook.com/share/v/abc"
+  }),
+  "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Fshare%2Fv%2Fabc"
 );
 assert.equal(redirectFor("https://facebook.com.example/reel/123"), undefined);
 assert.equal(redirectFor("https://notfacebook.com/reel/123"), undefined);

--- a/LinkRouter/Tests/GlowSafariRedirectTests.js
+++ b/LinkRouter/Tests/GlowSafariRedirectTests.js
@@ -16,13 +16,16 @@ const manifest = JSON.parse(
   )
 );
 
-assert.equal(manifest.version, "1.0.2");
+assert.equal(manifest.version, "1.0.3");
 assert.equal(manifest.content_scripts[0].run_at, "document_start");
 
 async function redirectFor(href, options = {}) {
   const url = new URL(href);
   let redirected;
   const storage = new Map();
+  if (options.legacyAttempted) {
+    storage.set(`glow-redirect:${href}`, "attempted");
+  }
   function makeDocument(source = options) {
     return {
       querySelectorAll(selector) {
@@ -98,6 +101,7 @@ assert.equal(
 );
 assert.equal(
   await redirectFor("https://www.facebook.com/share/v/19RsNqHveR/?mibextid=wwXIfr", {
+    legacyAttempted: true,
     fetched: {
       canonical: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/",
       openGraph: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/"

--- a/LinkRouter/Tests/GlowSafariRedirectTests.js
+++ b/LinkRouter/Tests/GlowSafariRedirectTests.js
@@ -9,11 +9,39 @@ const script = fs.readFileSync(
   path.join(__dirname, "..", "SafariExtensionResources", "redirect.js"),
   "utf8"
 );
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, "..", "SafariExtensionResources", "manifest.json"),
+    "utf8"
+  )
+);
 
-function redirectFor(href, options = {}) {
+assert.equal(manifest.version, "1.0.2");
+assert.equal(manifest.content_scripts[0].run_at, "document_start");
+
+async function redirectFor(href, options = {}) {
   const url = new URL(href);
   let redirected;
   const storage = new Map();
+  function makeDocument(source = options) {
+    return {
+      querySelectorAll(selector) {
+        let values = [];
+        if (selector === 'meta[property="al:ios:url"]') {
+          values = source.nativeRoutes ?? [];
+        } else if (selector === 'link[rel="canonical"]' && source.canonical) {
+          values = [source.canonical];
+        } else if (selector === 'meta[property="og:url"]' && source.openGraph) {
+          values = [source.openGraph];
+        }
+        return values.map((content) => ({
+          getAttribute(name) {
+            return name === "content" || name === "href" ? content : null;
+          }
+        }));
+      }
+    };
+  }
   const window = {
     location: {
       href,
@@ -30,64 +58,73 @@ function redirectFor(href, options = {}) {
       setItem(key, value) {
         storage.set(key, value);
       }
-    }
-  };
-  const document = {
-    querySelectorAll(selector) {
-      let values = [];
-      if (selector === 'meta[property="al:ios:url"]') {
-        values = options.nativeRoutes ?? [];
-      } else if (selector === 'link[rel="canonical"]' && options.canonical) {
-        values = [options.canonical];
-      } else if (selector === 'meta[property="og:url"]' && options.openGraph) {
-        values = [options.openGraph];
-      }
-      return values.map((content) => ({
-        getAttribute(name) {
-          return name === "content" || name === "href" ? content : null;
+    },
+    stop() {},
+    async fetch() {
+      return {
+        ok: options.fetchOK !== false,
+        status: options.fetchOK === false ? 500 : 200,
+        async text() {
+          return "<html></html>";
         }
-      }));
+      };
     }
   };
+  class DOMParser {
+    parseFromString() {
+      return makeDocument(options.fetched ?? options);
+    }
+  }
+  const document = makeDocument();
 
-  vm.runInNewContext(script, {URL, document, window});
+  vm.runInNewContext(script, {DOMParser, Error, URL, document, window});
+  await new Promise(setImmediate);
   return redirected;
 }
 
+async function main() {
 assert.equal(
-  redirectFor("https://www.facebook.com/reel/123?ref=share#clip", {
+  await redirectFor("https://www.facebook.com/reel/123?ref=share#clip", {
     nativeRoutes: ["fb://reel/123?ref=share"]
   }),
   "fb://reel/123?ref=share"
 );
 assert.equal(
-  redirectFor("https://www.facebook.com/share/r/abc/?mibextid=xyz", {
+  await redirectFor("https://www.facebook.com/share/r/abc/?mibextid=xyz", {
     nativeRoutes: ["https://evil.example/payload"],
     canonical: "https://www.facebook.com/reel/123"
   }),
   "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Freel%2F123"
 );
 assert.equal(
-  redirectFor("https://www.facebook.com/share/v/19RsNqHveR/?mibextid=wwXIfr", {
-    canonical: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/",
-    openGraph: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/"
+  await redirectFor("https://www.facebook.com/share/v/19RsNqHveR/?mibextid=wwXIfr", {
+    fetched: {
+      canonical: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/",
+      openGraph: "https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/"
+    }
   }),
   "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2FMEMES.of.the.NFL%2Fposts%2F1467604858743867%2F"
 );
 assert.equal(
-  redirectFor("https://www.facebook.com/share/v/abc", {
+  await redirectFor("https://www.facebook.com/share/v/abc", {
     canonical: "https://www.facebook.com/",
     openGraph: "https://www.facebook.com/share/v/abc"
   }),
   "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Fshare%2Fv%2Fabc"
 );
-assert.equal(redirectFor("https://facebook.com.example/reel/123"), undefined);
-assert.equal(redirectFor("https://notfacebook.com/reel/123"), undefined);
+assert.equal(await redirectFor("https://facebook.com.example/reel/123"), undefined);
+assert.equal(await redirectFor("https://notfacebook.com/reel/123"), undefined);
 assert.equal(
-  redirectFor(
+  await redirectFor(
     "https://www.facebook.com/reel/1071097325498008/?referral_source=external_link&surface_type=tab&in_reels_tab_context=TRUE"
   ),
   "fb-www-link://www_link/?url=https%3A%2F%2Fwww.facebook.com%2Freel%2F1071097325498008%2F%3Freferral_source%3Dexternal_link%26surface_type%3Dtab%26in_reels_tab_context%3DTRUE"
 );
 
 console.log("PASS GlowSafariRedirectTests");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/LinkRouter/project.yml
+++ b/LinkRouter/project.yml
@@ -1,0 +1,77 @@
+name: GlowLinkRouter
+options:
+  bundleIdPrefix: com.facebook.Facebook
+  deploymentTarget:
+    iOS: "15.1"
+settings:
+  base:
+    ARCHS: arm64
+    ONLY_ACTIVE_ARCH: NO
+    ENABLE_BITCODE: NO
+    CLANG_ENABLE_MODULES: YES
+    CLANG_ENABLE_OBJC_ARC: YES
+    APPLICATION_EXTENSION_API_ONLY: YES
+targets:
+  GlowLinkShare:
+    type: app-extension
+    platform: iOS
+    sources:
+      - Sources
+    info:
+      path: Info.plist
+      properties:
+        CFBundleDisplayName: Facebook Glow - Open Link
+        CFBundleName: GlowLinkShare
+        CFBundleShortVersionString: "1.0.0"
+        CFBundleVersion: "1"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          NSExtensionPrincipalClass: GlowLinkShareViewController
+          NSExtensionAttributes:
+            NSExtensionActivationRule:
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+              NSExtensionActivationSupportsText: true
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.facebook.Facebook.GlowLinkShare
+        PRODUCT_NAME: GlowLinkShare
+        SKIP_INSTALL: YES
+        GENERATE_INFOPLIST_FILE: NO
+        CODE_SIGNING_ALLOWED: NO
+        CODE_SIGNING_REQUIRED: NO
+        CODE_SIGN_IDENTITY: ""
+  GlowSafariRedirect:
+    type: app-extension
+    platform: iOS
+    sources:
+      - SafariExtensionSources
+      - path: SafariExtensionResources
+        buildPhase: resources
+    info:
+      path: SafariExtension-Info.plist
+      properties:
+        CFBundleDisplayName: Open Facebook in Glow
+        CFBundleName: GlowSafariRedirect
+        CFBundleShortVersionString: "1.0.0"
+        CFBundleVersion: "1"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.Safari.web-extension
+          NSExtensionPrincipalClass: GlowSafariWebExtensionHandler
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.facebook.Facebook.GlowSafariRedirect
+        PRODUCT_NAME: GlowSafariRedirect
+        SKIP_INSTALL: YES
+        GENERATE_INFOPLIST_FILE: NO
+        CODE_SIGNING_ALLOWED: NO
+        CODE_SIGNING_REQUIRED: NO
+        CODE_SIGN_IDENTITY: ""
+schemes:
+  GlowLinkShare:
+    build:
+      targets:
+        GlowLinkShare: all
+  GlowSafariRedirect:
+    build:
+      targets:
+        GlowSafariRedirect: all

--- a/LinkRouter/project.yml
+++ b/LinkRouter/project.yml
@@ -22,7 +22,7 @@ targets:
       properties:
         CFBundleDisplayName: Facebook Glow - Open Link
         CFBundleName: GlowLinkShare
-        CFBundleShortVersionString: "1.0.0"
+        CFBundleShortVersionString: "1.0.1"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
@@ -52,7 +52,7 @@ targets:
       properties:
         CFBundleDisplayName: Open Facebook in Glow
         CFBundleName: GlowSafariRedirect
-        CFBundleShortVersionString: "1.0.0"
+        CFBundleShortVersionString: "1.0.1"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.Safari.web-extension

--- a/LinkRouter/project.yml
+++ b/LinkRouter/project.yml
@@ -22,7 +22,7 @@ targets:
       properties:
         CFBundleDisplayName: Facebook Glow - Open Link
         CFBundleName: GlowLinkShare
-        CFBundleShortVersionString: "1.0.2"
+        CFBundleShortVersionString: "1.0.3"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
@@ -52,7 +52,7 @@ targets:
       properties:
         CFBundleDisplayName: Open Facebook in Glow
         CFBundleName: GlowSafariRedirect
-        CFBundleShortVersionString: "1.0.2"
+        CFBundleShortVersionString: "1.0.3"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.Safari.web-extension

--- a/LinkRouter/project.yml
+++ b/LinkRouter/project.yml
@@ -22,7 +22,7 @@ targets:
       properties:
         CFBundleDisplayName: Facebook Glow - Open Link
         CFBundleName: GlowLinkShare
-        CFBundleShortVersionString: "1.0.1"
+        CFBundleShortVersionString: "1.0.2"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
@@ -52,7 +52,7 @@ targets:
       properties:
         CFBundleDisplayName: Open Facebook in Glow
         CFBundleName: GlowSafariRedirect
-        CFBundleShortVersionString: "1.0.1"
+        CFBundleShortVersionString: "1.0.2"
         CFBundleVersion: "1"
         NSExtension:
           NSExtensionPointIdentifier: com.apple.Safari.web-extension

--- a/LinkRouter/test.sh
+++ b/LinkRouter/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/glow-link-tests.XXXXXX")"
+trap 'rm -rf "$build_dir"' EXIT
+
+xcrun clang \
+  -fobjc-arc \
+  -fblocks \
+  -framework Foundation \
+  -I"$root/Sources" \
+  "$root/Sources/GlowLinkRouting.m" \
+  "$root/Tests/GlowLinkRoutingTests.m" \
+  -o "$build_dir/GlowLinkRoutingTests"
+
+"$build_dir/GlowLinkRoutingTests"
+node "$root/Tests/GlowSafariRedirectTests.js"

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ Review by [@qbap](https://github.com/qbap) on ONE Jailbreak: https://onejailbrea
   <li>Make sure all inputs are correct, then click <strong>Run workflow</strong> to start the process.</li>
   <li>Wait for the build to finish. You can download <strong>Glow for Facebook</strong> app from the releases section of your forked repo. (If you can't find the releases section, go to your forked repo and add /releases to the URL, i.e., github.com/user/Glow/releases.)</li>
 </ol>
+
+## Opening Facebook links in Glow
+
+Builds created by the workflow include **Open Facebook in Glow**, a Safari Web
+Extension that preserves the selected post, Reel, profile, or Watch URL when
+handing it to Facebook. Enable it in **Settings → Apps → Safari → Extensions**
+and grant access to the listed Facebook domains. The Share Sheet also includes
+**Facebook Glow - Open Link** as an explicit fallback.
+
+The router validates Facebook-family hosts and uses Facebook's registered
+`fb-www-link://www_link/?url=...` route when page metadata does not provide a
+safe native route. Sideloaded builds cannot claim Meta's Universal Links, so a
+brief Safari handoff and a first-use confirmation prompt may still appear.

--- a/scripts/embed-glow-link-router.sh
+++ b/scripts/embed-glow-link-router.sh
@@ -79,4 +79,4 @@ rm -f "$output_parent/$output_name"
 )
 unzip -tq "$output_parent/$output_name"
 
-printf 'Embedded Glow Link Router 1.0.2 into %s (%s)\n' "$bundle_id" "$version"
+printf 'Embedded Glow Link Router 1.0.3 into %s (%s)\n' "$bundle_id" "$version"

--- a/scripts/embed-glow-link-router.sh
+++ b/scripts/embed-glow-link-router.sh
@@ -79,4 +79,4 @@ rm -f "$output_parent/$output_name"
 )
 unzip -tq "$output_parent/$output_name"
 
-printf 'Embedded Glow Link Router 1.0.1 into %s (%s)\n' "$bundle_id" "$version"
+printf 'Embedded Glow Link Router 1.0.2 into %s (%s)\n' "$bundle_id" "$version"

--- a/scripts/embed-glow-link-router.sh
+++ b/scripts/embed-glow-link-router.sh
@@ -79,4 +79,4 @@ rm -f "$output_parent/$output_name"
 )
 unzip -tq "$output_parent/$output_name"
 
-printf 'Embedded Glow Link Router 1.0.0 into %s (%s)\n' "$bundle_id" "$version"
+printf 'Embedded Glow Link Router 1.0.1 into %s (%s)\n' "$bundle_id" "$version"

--- a/scripts/embed-glow-link-router.sh
+++ b/scripts/embed-glow-link-router.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+router_root="$repo_root/LinkRouter"
+input_ipa="${1:?Usage: embed-glow-link-router.sh INPUT_IPA OUTPUT_IPA}"
+output_ipa="${2:?Usage: embed-glow-link-router.sh INPUT_IPA OUTPUT_IPA}"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/glow-link-router.XXXXXX")"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f "$input_ipa" ]] || fail "Input IPA not found: $input_ipa"
+[[ -f "$router_root/project.yml" ]] || fail "Link Router project is missing"
+command -v xcodegen >/dev/null || fail "xcodegen is required"
+
+"$router_root/test.sh"
+xcodegen generate --spec "$router_root/project.yml" --project "$router_root"
+
+for scheme in GlowLinkShare GlowSafariRedirect; do
+  xcodebuild \
+    -project "$router_root/GlowLinkRouter.xcodeproj" \
+    -scheme "$scheme" \
+    -configuration Release \
+    -sdk iphoneos \
+    -derivedDataPath "$router_root/.build" \
+    CODE_SIGNING_ALLOWED=NO \
+    build >/dev/null
+done
+
+products="$router_root/.build/Build/Products/Release-iphoneos"
+share_product="$products/GlowLinkShare.appex"
+safari_product="$products/GlowSafariRedirect.appex"
+[[ -x "$share_product/GlowLinkShare" ]] || fail "Share extension did not build"
+[[ -x "$safari_product/GlowSafariRedirect" ]] || fail "Safari extension did not build"
+
+unzip -q "$input_ipa" -d "$work_dir/archive"
+app_path="$(find "$work_dir/archive/Payload" -maxdepth 1 -type d -name '*.app' -print -quit)"
+[[ -n "$app_path" ]] || fail "No app bundle found in IPA"
+
+bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
+version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app_path/Info.plist")"
+build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app_path/Info.plist")"
+[[ -n "$bundle_id" && -n "$version" && -n "$build" ]] || fail "App metadata is incomplete"
+
+plugins="$app_path/PlugIns"
+mkdir -p "$plugins"
+rm -rf "$plugins/GlowLinkShare.appex" "$plugins/GlowSafariRedirect.appex"
+cp -R "$share_product" "$plugins/GlowLinkShare.appex"
+cp -R "$safari_product" "$plugins/GlowSafariRedirect.appex"
+
+share_path="$plugins/GlowLinkShare.appex"
+safari_path="$plugins/GlowSafariRedirect.appex"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_id.GlowLinkShare" "$share_path/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_id.GlowSafariRedirect" "$safari_path/Info.plist"
+for extension_path in "$share_path" "$safari_path"; do
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$extension_path/Info.plist"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build" "$extension_path/Info.plist"
+  rm -rf "$extension_path/_CodeSignature"
+done
+
+[[ -f "$safari_path/manifest.json" ]] || fail "Safari manifest is missing"
+grep -Fq 'fb-www-link://www_link/?url=' "$safari_path/redirect.js" ||
+  fail "Destination-preserving route is missing"
+
+output_parent="$(cd "$(dirname "$output_ipa")" && pwd)"
+output_name="$(basename "$output_ipa")"
+rm -f "$output_parent/$output_name"
+(
+  cd "$work_dir/archive"
+  zip -q -6 -r "$output_parent/$output_name" Payload
+)
+unzip -tq "$output_parent/$output_name"
+
+printf 'Embedded Glow Link Router 1.0.0 into %s (%s)\n' "$bundle_id" "$version"


### PR DESCRIPTION
## Why

Facebook links opened from Messages or Safari can launch a sideloaded Glow build but lose the selected destination and land on the main timeline. Sideloaded builds cannot claim Meta's Universal Links, and the former `fb://faceweb/f?href=...` fallback does not reliably preserve destinations on current Facebook builds.

Facebook's `/share/p/`, `/share/r/`, and `/share/v/` pages are wrappers. They expose the real post through canonical and Open Graph metadata, but handing the wrapper itself to Facebook can still open Home.

@dayanch96, please review the workflow integration and the two companion extensions, especially the `fb-www-link://www_link/?url=...` handoff contract and the validated wrapper resolution.

## What changed

- Add a source-built Safari Web Extension that validates Facebook-family URLs and hands the selected URL to Facebook's registered WWW-link route.
- Resolve `/share/p/`, `/share/r/`, and `/share/v/` wrappers to a safe Facebook canonical or Open Graph destination.
- Reject Home destinations, recursive share wrappers, malformed inputs, and lookalike hosts.
- Keep the full current URL for normal Facebook links and fall back to the original wrapper when no useful destination exists.
- Add **Facebook Glow - Open Link** to the Share Sheet as an explicit fallback.
- Embed both unsigned extensions into the generated IPA using the workflow-selected bundle identifier and app version. Downstream sideload signing remains unchanged.
- Preserve unrelated existing app extensions instead of replacing the entire `PlugIns` directory.
- Add exact Reel and share-video regression coverage, an arm64 extension build check, and user-facing setup documentation.
- Quote GitHub environment paths and pass workflow inputs through environment variables to keep the edited workflow shell-safe.

## Verification

Both exact URLs below were physically accepted on an iPhone 15 Pro running iOS 26.6. Each opened its selected destination in Glow instead of the main timeline.

```text
https://www.facebook.com/reel/1071097325498008/?referral_source=external_link&surface_type=tab&in_reels_tab_context=TRUE
https://www.facebook.com/share/v/19RsNqHveR/?mibextid=wwXIfr
```

The share-video wrapper resolved to:

```text
https://www.facebook.com/MEMES.of.the.NFL/posts/1467604858743867/
```

The Objective-C routing tests and JavaScript redirect regressions pass, both extensions build as unsigned arm64 iOS app extensions, and the embedding script produced a structurally valid IPA containing bundle-ID-matched Share and Safari extensions. The final signed 1.0.1 build passed archive integrity, deep strict signature verification, in-place installation, native route launch, and physical destination acceptance. No decrypted IPA, signed artifact, provisioning profile, certificate, or secret is included in this PR.
